### PR TITLE
use PATH_MAX for size of epub_path buffer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -355,7 +355,7 @@ int main (int argc, char **argv)
         if (f > 0)
           {
 	  close (f);
-	  char epub_path[1024];
+	  char epub_path[PATH_MAX];
 	  realpath (epub_file, epub_path); 
 	  unlink (epub_path);
 	  char *content;


### PR DESCRIPTION
After building on an Ubuntu 22.04 system, trying to convert a text file resulted in the program aborting with the following message:
```
*** buffer overflow detected ***: terminated
```

Changing the size of the epub_path buffer to `PATH_MAX` or a hardcoded 4096 fixed the problem for me.